### PR TITLE
Update 2023-02-06 2128H | v0.5.0

### DIFF
--- a/docs/contributions/templates/shellscript/apt/compile.sh
+++ b/docs/contributions/templates/shellscript/apt/compile.sh
@@ -16,6 +16,7 @@ DEPENDENCIES=(place your dependencies here)
 # Package Information
 PKG_AUTHOR="AUTHOR_NAME_HERE"
 PKG_NAME="REPOSITORY_NAME_HERE"
+BIN_NAME="PACKAGE BINARY HERE" # Binary Name
 SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
 
 # Functions

--- a/docs/contributions/templates/shellscript/apt/uninstaller.sh
+++ b/docs/contributions/templates/shellscript/apt/uninstaller.sh
@@ -1,0 +1,57 @@
+#!/bin/env bash
+: "
+Manual Built from Source Package Uninstaller
+
+Uninstall manually compiled from source packages installed to host system
+
+Target Base System: Debian 
+Target Package Manager: apt
+"
+
+# Build Info
+CC="make"
+CFLAGS="CMAKE_BUILD_TYPE=RelWithDebInfo"
+DEPENDENCIES=(git ninja-build gettext libtool libtool-bin autoconf automake cmake g++ pkg-config unzip curl doxygen)
+
+# Package Information
+PKG_AUTHOR="neovim"
+PKG_NAME="neovim"
+BIN_NAME="nvim" # Binary Name
+SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
+
+# Functions
+setup()
+{
+    : "
+    Setup all dependencies required to build
+    "
+
+    # Check if package is installed
+    pkg_locations="$(which $BIN_NAME)"
+    if [[ "$?" -gt 0 ]]; then
+        # = 0 = OK
+        # > 0 = Error
+        echo -e "Package $BIN_NAME is not installed."
+        exit 1
+    fi
+}
+
+uninstall_pkg()
+{
+    : "
+    Uninstall the manually built from source package from host system
+    "
+    rm -f $(which $BIN_NAME) && \
+        echo -e "[+] Uninstallation of $PKG_NAME Successful." || \
+        echo -e "[-] Uninstallation of $PKG_NAME Error."
+}
+
+main()
+{
+    uninstall_pkg
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    setup
+    main "$@"
+fi

--- a/docs/contributions/templates/shellscript/general/compile.sh
+++ b/docs/contributions/templates/shellscript/general/compile.sh
@@ -1,26 +1,20 @@
 #!/bin/env bash
 : "
-Eclipse JDTLS Install
+Manual Build from Source script
 
-Method: Compile from Scratch to ensure that it is on the latest version
-
-Target Base System: ArchLinux 
-Target Package Manager: pacman
-Reference Link: https://github.com/eclipse/eclipse.jdt.ls#installation
+Target Base System: NIL
+Target Package Manager: NIL
 "
 
 # Build Info
-CC="./mvnw"
-CFLAGS="-DskipTests=true clean verify"
-DEPENDENCIES=(git ninja gettext libtool autoconf automake cmake base-devel pkg-config unzip curl ncurses jdk-openjdk)
-
-# Additional Compile/Build Information
-JAVA_VERSION="19"
-JAVA_HOME="/usr/lib/jvm/java-$JAVA_VERSION-openjdk"
+CC="make"
+CFLAGS="CMAKE_BUILD_TYPE=RelWithDebInfo"
+DEPENDENCIES=(git ninja gettext libtool autoconf automake cmake base-devel)
 
 # Package Information
-PKG_AUTHOR="eclipse"
-PKG_NAME="eclipse.jdt.ls"
+PKG_AUTHOR="[repo-author-name]"
+PKG_NAME="[repo-package-name]"
+BIN_NAME="[package-binary]" # Binary Name
 SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
 
 # Functions
@@ -31,7 +25,7 @@ setup()
     "
 
     # Install dependencies
-    pacman -S "${DEPENDENCIES[@]}"
+    # [your-package-installer-here] "${DEPENDENCIES[@]}"
 
     # Clone repository
     git clone "$SRC_URL"
@@ -73,7 +67,7 @@ clean()
 main()
 {
     build
-    # install
+    install
     # clean
 }
 

--- a/docs/contributions/templates/shellscript/general/uninstaller.sh
+++ b/docs/contributions/templates/shellscript/general/uninstaller.sh
@@ -1,0 +1,57 @@
+#!/bin/env bash
+: "
+Manual Built from Source Package Uninstaller
+
+Uninstall manually compiled from source packages installed to host system
+
+Target Base System: NIL
+Target Package Manager: NIL
+"
+
+# Build Info
+CC="make"
+CFLAGS="CMAKE_BUILD_TYPE=RelWithDebInfo"
+DEPENDENCIES=(git ninja gettext libtool autoconf automake cmake base-devel)
+
+# Package Information
+PKG_AUTHOR="[repo-author-name]"
+PKG_NAME="[repo-package-name]"
+BIN_NAME="[package-binary]" # Binary Name
+SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
+
+# Functions
+setup()
+{
+    : "
+    Setup all dependencies required to build
+    "
+
+    # Check if package is installed
+    pkg_locations="$(which $BIN_NAME)"
+    if [[ "$?" -gt 0 ]]; then
+        # = 0 = OK
+        # > 0 = Error
+        echo -e "Package $BIN_NAME is not installed."
+        exit 1
+    fi
+}
+
+uninstall_pkg()
+{
+    : "
+    Uninstall the manually built from source package from host system
+    "
+    rm -f $(which $BIN_NAME) && \
+        echo -e "[+] Uninstallation of $PKG_NAME Successful." || \
+        echo -e "[-] Uninstallation of $PKG_NAME Error."
+}
+
+main()
+{
+    uninstall_pkg
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    setup
+    main "$@"
+fi

--- a/docs/contributions/templates/shellscript/pacman/compile.sh
+++ b/docs/contributions/templates/shellscript/pacman/compile.sh
@@ -1,26 +1,20 @@
 #!/bin/env bash
 : "
-Eclipse JDTLS Install
-
-Method: Compile from Scratch to ensure that it is on the latest version
+Manual Build from Source script
 
 Target Base System: ArchLinux 
 Target Package Manager: pacman
-Reference Link: https://github.com/eclipse/eclipse.jdt.ls#installation
 "
 
 # Build Info
-CC="./mvnw"
-CFLAGS="-DskipTests=true clean verify"
-DEPENDENCIES=(git ninja gettext libtool autoconf automake cmake base-devel pkg-config unzip curl ncurses jdk-openjdk)
-
-# Additional Compile/Build Information
-JAVA_VERSION="19"
-JAVA_HOME="/usr/lib/jvm/java-$JAVA_VERSION-openjdk"
+CC="make"
+CFLAGS="CMAKE_BUILD_TYPE=RelWithDebInfo"
+DEPENDENCIES=(git ninja gettext libtool autoconf automake cmake base-devel)
 
 # Package Information
-PKG_AUTHOR="eclipse"
-PKG_NAME="eclipse.jdt.ls"
+PKG_AUTHOR="[repo-author-name]"
+PKG_NAME="[repo-package-name]"
+BIN_NAME="[package-binary]" # Binary Name
 SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
 
 # Functions
@@ -73,7 +67,7 @@ clean()
 main()
 {
     build
-    # install
+    install
     # clean
 }
 

--- a/docs/contributions/templates/shellscript/pacman/uninstaller.sh
+++ b/docs/contributions/templates/shellscript/pacman/uninstaller.sh
@@ -1,0 +1,57 @@
+#!/bin/env bash
+: "
+Manual Built from Source Package Uninstaller
+
+Uninstall manually compiled from source packages installed to host system
+
+Target Base System: ArchLinux 
+Target Package Manager: pacman
+"
+
+# Build Info
+CC="make"
+CFLAGS="CMAKE_BUILD_TYPE=RelWithDebInfo"
+DEPENDENCIES=(git ninja gettext libtool autoconf automake cmake base-devel)
+
+# Package Information
+PKG_AUTHOR="[repo-author-name]"
+PKG_NAME="[repo-package-name]"
+BIN_NAME="[package-binary]" # Binary Name
+SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
+
+# Functions
+setup()
+{
+    : "
+    Setup all dependencies required to build
+    "
+
+    # Check if package is installed
+    pkg_locations="$(which $BIN_NAME)"
+    if [[ "$?" -gt 0 ]]; then
+        # = 0 = OK
+        # > 0 = Error
+        echo -e "Package $BIN_NAME is not installed."
+        exit 1
+    fi
+}
+
+uninstall_pkg()
+{
+    : "
+    Uninstall the manually built from source package from host system
+    "
+    rm -f $(which $BIN_NAME) && \
+        echo -e "[+] Uninstallation of $PKG_NAME Successful." || \
+        echo -e "[-] Uninstallation of $PKG_NAME Error."
+}
+
+main()
+{
+    uninstall_pkg
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    setup
+    main "$@"
+fi

--- a/packages/github/baskerville/bspwm/pacman/compile.sh
+++ b/packages/github/baskerville/bspwm/pacman/compile.sh
@@ -1,26 +1,21 @@
 #!/bin/env bash
 : "
-Eclipse JDTLS Install
+bspwm manual installation
 
 Method: Compile from Scratch to ensure that it is on the latest version
 
 Target Base System: ArchLinux 
 Target Package Manager: pacman
-Reference Link: https://github.com/eclipse/eclipse.jdt.ls#installation
 "
 
 # Build Info
-CC="./mvnw"
-CFLAGS="-DskipTests=true clean verify"
-DEPENDENCIES=(git ninja gettext libtool autoconf automake cmake base-devel pkg-config unzip curl ncurses jdk-openjdk)
-
-# Additional Compile/Build Information
-JAVA_VERSION="19"
-JAVA_HOME="/usr/lib/jvm/java-$JAVA_VERSION-openjdk"
+CC="make"
+CFLAGS="CMAKE_BUILD_TYPE=RelWithDebInfo"
+DEPENDENCIES=(git libxinerama xcb-util libxcb xcb-util-wm xcb-util-keysyms)
 
 # Package Information
-PKG_AUTHOR="eclipse"
-PKG_NAME="eclipse.jdt.ls"
+PKG_AUTHOR="baskerville"
+PKG_NAME="bspwm"
 SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
 
 # Functions
@@ -73,7 +68,7 @@ clean()
 main()
 {
     build
-    # install
+    install
     # clean
 }
 

--- a/packages/github/baskerville/sxhkd/pacman/compile.sh
+++ b/packages/github/baskerville/sxhkd/pacman/compile.sh
@@ -1,26 +1,21 @@
 #!/bin/env bash
 : "
-Eclipse JDTLS Install
+sxhkd manual installation
 
 Method: Compile from Scratch to ensure that it is on the latest version
 
 Target Base System: ArchLinux 
 Target Package Manager: pacman
-Reference Link: https://github.com/eclipse/eclipse.jdt.ls#installation
 "
 
 # Build Info
-CC="./mvnw"
-CFLAGS="-DskipTests=true clean verify"
-DEPENDENCIES=(git ninja gettext libtool autoconf automake cmake base-devel pkg-config unzip curl ncurses jdk-openjdk)
-
-# Additional Compile/Build Information
-JAVA_VERSION="19"
-JAVA_HOME="/usr/lib/jvm/java-$JAVA_VERSION-openjdk"
+CC="make"
+CFLAGS="CMAKE_BUILD_TYPE=RelWithDebInfo"
+DEPENDENCIES=(git)
 
 # Package Information
-PKG_AUTHOR="eclipse"
-PKG_NAME="eclipse.jdt.ls"
+PKG_AUTHOR="baskerville"
+PKG_NAME="sxhkd"
 SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
 
 # Functions
@@ -73,7 +68,7 @@ clean()
 main()
 {
     build
-    # install
+    install
     # clean
 }
 

--- a/packages/github/kovidgoyal/kitty/pacman/compile.sh
+++ b/packages/github/kovidgoyal/kitty/pacman/compile.sh
@@ -1,6 +1,6 @@
 #!/bin/env bash
 : "
-Tmux Install
+Kitty terminal emulator manual installation
 
 Method: Compile from Scratch to ensure that it is on the latest version
 
@@ -11,11 +11,11 @@ Target Package Manager: pacman
 # Build Info
 CC="make"
 CFLAGS="CMAKE_BUILD_TYPE=RelWithDebInfo"
-DEPENDENCIES=(ninja gettext libtool autoconf automake cmake base-devel pkg-config unzip curl ncurses)
+DEPENDENCIES=(git libxrandr go python3 python-pip harfbuzz zlib libpng lcms2 librsync openssl freetype2 fontconfig libcanberra imagemagick python-pygments gcc pkg-config libxinerama xcb-util libxcb xcb-util-wm xcb-util-keysyms libgl mesa libxkbcommon libxkbcommon-x11 libxcursor libxi wayland-protocols)
 
 # Package Information
-PKG_AUTHOR="tmux"
-PKG_NAME="tmux"
+PKG_AUTHOR="kovidgoyal"
+PKG_NAME="kitty"
 SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
 
 # Functions
@@ -35,20 +35,6 @@ setup()
     cd $PKG_NAME
 }
 
-configure()
-{
-    : "
-    Configure the source code
-    "
-    # Auto-generate configuration file
-    sh autogen.sh
-
-    # Configure source code
-    ./configure && \
-        echo -e "[+] Configuration Successful." || \
-        echo -e "[-] Configuration Error."
-}
-
 build()
 {
     : "
@@ -64,9 +50,20 @@ install()
     : "
     Install and move the compiled binary to the host system
     "
-    ${CC} install && \
+    ln -sf ${PWD}/kitty/launcher/kitty /usr/local/bin/kitty && \
         echo -e "[+] Installation Successful." || \
         echo -e "[-] Installation Error."
+}
+
+generate_local_Docs()
+{
+    : "
+    Setup the kitty documentation available locally
+    "
+    python3 -m pip install -Ur docs/requirements.txt && \
+        make docs && \
+            echo -e "[+] Documents generated successfully" || \
+            echo -e "[-] Error generating Documents"
 }
 
 clean()
@@ -81,10 +78,10 @@ clean()
 
 main()
 {
-    configure
     build
     install
     # clean
+    generate_local_Docs
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/packages/github/neovim/neovim/apt/compile.sh
+++ b/packages/github/neovim/neovim/apt/compile.sh
@@ -11,11 +11,12 @@ Target Package Manager: apt
 # Build Info
 CC="make"
 CFLAGS="CMAKE_BUILD_TYPE=RelWithDebInfo"
-DEPENDENCIES=(ninja-build gettext libtool libtool-bin autoconf automake cmake g++ pkg-config unzip curl doxygen)
+DEPENDENCIES=(git ninja-build gettext libtool libtool-bin autoconf automake cmake g++ pkg-config unzip curl doxygen)
 
 # Package Information
 PKG_AUTHOR="neovim"
 PKG_NAME="neovim"
+BIN_NAME="nvim" # Binary Name
 SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
 
 # Functions

--- a/packages/github/neovim/neovim/apt/uninstaller.sh
+++ b/packages/github/neovim/neovim/apt/uninstaller.sh
@@ -1,0 +1,57 @@
+#!/bin/env bash
+: "
+Manual Built from Source Package Uninstaller
+
+Uninstall manually compiled from source packages installed to host system
+
+Target Base System: Debian 
+Target Package Manager: apt
+"
+
+# Build Info
+CC="make"
+CFLAGS="CMAKE_BUILD_TYPE=RelWithDebInfo"
+DEPENDENCIES=(git ninja-build gettext libtool libtool-bin autoconf automake cmake g++ pkg-config unzip curl doxygen)
+
+# Package Information
+PKG_AUTHOR="neovim"
+PKG_NAME="neovim"
+BIN_NAME="nvim" # Binary Name
+SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
+
+# Functions
+setup()
+{
+    : "
+    Setup all dependencies required to build
+    "
+
+    # Check if package is installed
+    pkg_locations="$(which $BIN_NAME)"
+    if [[ "$?" -gt 0 ]]; then
+        # = 0 = OK
+        # > 0 = Error
+        echo -e "Package $BIN_NAME is not installed."
+        exit 1
+    fi
+}
+
+uninstall_pkg()
+{
+    : "
+    Uninstall the manually built from source package from host system
+    "
+    rm -f $(which $BIN_NAME) && \
+        echo -e "[+] Uninstallation of $PKG_NAME Successful." || \
+        echo -e "[-] Uninstallation of $PKG_NAME Error."
+}
+
+main()
+{
+    uninstall_pkg
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    setup
+    main "$@"
+fi

--- a/packages/github/neovim/neovim/pacman/compile.sh
+++ b/packages/github/neovim/neovim/pacman/compile.sh
@@ -11,11 +11,12 @@ Target Package Manager: pacman
 # Build Info
 CC="make"
 CFLAGS="CMAKE_BUILD_TYPE=RelWithDebInfo"
-DEPENDENCIES=(ninja gettext libtool autoconf automake cmake base-devel pkg-config unzip curl doxygen)
+DEPENDENCIES=(git ninja gettext libtool autoconf automake cmake base-devel pkg-config unzip curl doxygen)
 
 # Package Information
 PKG_AUTHOR="neovim"
 PKG_NAME="neovim"
+BIN_NAME="nvim" # Binary Name
 SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
 
 # Functions

--- a/packages/github/neovim/neovim/pacman/uninstaller.sh
+++ b/packages/github/neovim/neovim/pacman/uninstaller.sh
@@ -1,0 +1,57 @@
+#!/bin/env bash
+: "
+Manual Built from Source Package Uninstaller
+
+Uninstall manually compiled from source packages installed to host system
+
+Target Base System: ArchLinux 
+Target Package Manager: pacman
+"
+
+# Build Info
+CC="make"
+CFLAGS="CMAKE_BUILD_TYPE=RelWithDebInfo"
+DEPENDENCIES=(git ninja gettext libtool autoconf automake cmake base-devel pkg-config unzip curl doxygen)
+
+# Package Information
+PKG_AUTHOR="neovim"
+PKG_NAME="neovim"
+BIN_NAME="nvim" # Binary Name
+SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
+
+# Functions
+setup()
+{
+    : "
+    Setup all dependencies required to build
+    "
+
+    # Check if package is installed
+    pkg_locations="$(which $BIN_NAME)"
+    if [[ "$?" -gt 0 ]]; then
+        # = 0 = OK
+        # > 0 = Error
+        echo -e "Package $BIN_NAME is not installed."
+        exit 1
+    fi
+}
+
+uninstall_pkg()
+{
+    : "
+    Uninstall the manually built from source package from host system
+    "
+    rm -f $(which $BIN_NAME) && \
+        echo -e "[+] Uninstallation of $PKG_NAME Successful." || \
+        echo -e "[-] Uninstallation of $PKG_NAME Error."
+}
+
+main()
+{
+    uninstall_pkg
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    setup
+    main "$@"
+fi

--- a/packages/github/tmux/tmux/pacman/compile.sh
+++ b/packages/github/tmux/tmux/pacman/compile.sh
@@ -1,26 +1,21 @@
 #!/bin/env bash
 : "
-Eclipse JDTLS Install
+Tmux Install
 
 Method: Compile from Scratch to ensure that it is on the latest version
 
 Target Base System: ArchLinux 
 Target Package Manager: pacman
-Reference Link: https://github.com/eclipse/eclipse.jdt.ls#installation
 "
 
 # Build Info
-CC="./mvnw"
-CFLAGS="-DskipTests=true clean verify"
-DEPENDENCIES=(git ninja gettext libtool autoconf automake cmake base-devel pkg-config unzip curl ncurses jdk-openjdk)
-
-# Additional Compile/Build Information
-JAVA_VERSION="19"
-JAVA_HOME="/usr/lib/jvm/java-$JAVA_VERSION-openjdk"
+CC="make"
+CFLAGS="CMAKE_BUILD_TYPE=RelWithDebInfo"
+DEPENDENCIES=(git ninja gettext libtool autoconf automake cmake base-devel pkg-config unzip curl ncurses)
 
 # Package Information
-PKG_AUTHOR="eclipse"
-PKG_NAME="eclipse.jdt.ls"
+PKG_AUTHOR="tmux"
+PKG_NAME="tmux"
 SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
 
 # Functions
@@ -38,6 +33,20 @@ setup()
 
     # Change directory into repository
     cd $PKG_NAME
+}
+
+configure()
+{
+    : "
+    Configure the source code
+    "
+    # Auto-generate configuration file
+    sh autogen.sh
+
+    # Configure source code
+    ./configure && \
+        echo -e "[+] Configuration Successful." || \
+        echo -e "[-] Configuration Error."
 }
 
 build()
@@ -72,8 +81,9 @@ clean()
 
 main()
 {
+    configure
     build
-    # install
+    install
     # clean
 }
 


### PR DESCRIPTION
- Created build script template(s) - compilation and uninstaller in shellscript for + apt + pacman + general (No specific package manager)
- Create build script for github repositories + baskerville/bspwm in pacman, apt still testing + baskerville/sxhkd in pacman, apt still testing + kovidgoyal/kitty  in pacman, apt still testing
- Created manual compilation (build from source) uninstaller script for use in tandem/corresponding with the compile.sh script for + neovim/neovim in pacman and apt
- Added 'git' as dependency for + eclipse/eclipse.jdt.ls in pacman + tmux/tmux in pacman
- Moved + tmux to 'tmux/tmux'