### PR TITLE
Update 2023-04-07 1151H | merge-rpi-clone-to-main

### DIFF
--- a/packages/github/billw2/rpi-clone/installer.sh
+++ b/packages/github/billw2/rpi-clone/installer.sh
@@ -1,0 +1,48 @@
+#!/bin/env bash
+: "
+Manual Built from Source Package Installer
+Install manually compiled from source packages to host system
+"
+
+# Functions
+setup()
+{
+    : "
+    Setup all dependencies required to build
+    "
+    # Source settings file
+    source $PWD/settings.sh
+
+    # Check if target files/folders exists
+    pkg_exists=0
+    if [[ -d "$PKG_NAME" ]]; then
+        # Package folder exists
+        pkg_exists=1
+
+        # Change directory into source code
+        cd $PKG_NAME
+    else
+        echo -e "Package repository directory does not exists."
+        exit
+    fi
+}
+
+begin_install()
+{
+    : "
+    Install the binary
+    "
+    if [[ "$pkg_exists" == "1" ]]; then
+        # If target folder exists
+        # Copy to system files
+        sudo cp "${BIN_NAMES[@]}" /usr/local/bin/ && \
+            echo -e "[+] Installation Successful." || \
+            echo -e "[-] Installation Error."
+    fi
+}
+
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    setup
+    begin_install
+fi

--- a/packages/github/billw2/rpi-clone/settings.sh
+++ b/packages/github/billw2/rpi-clone/settings.sh
@@ -1,0 +1,15 @@
+#!/bin/env bash
+: "
+Settings for the manual builders
+"
+
+# Build Info
+CC="make"
+CFLAGS="" # Use 4 cores/threads
+DEPENDENCIES=(git wget golang)
+
+# Package Information
+PKG_AUTHOR="billw2"
+PKG_NAME="rpi-clone"
+SRC_URL="https://github.com/$PKG_AUTHOR/$PKG_NAME"
+BIN_NAMES=("rpi-clone" "rpi-clone-setup")

--- a/packages/github/billw2/rpi-clone/setup.sh
+++ b/packages/github/billw2/rpi-clone/setup.sh
@@ -1,0 +1,47 @@
+#!/bin/env bash
+: "
+Setup repository and system structure for compilation
+
+Method: Compile from Scratch to ensure that it is on the latest version
+
+Target Base System: Debian
+Target Package Manager: apt
+"
+
+source_files()
+{
+    # Source settings file
+    source $PWD/settings.sh
+}
+
+install_dependencies()
+{
+    : "
+    Install and setup dependencies
+    "
+    # Install dependencies
+    sudo apt install "${DEPENDENCIES[@]}"
+}
+
+obtain_repository()
+{
+    # Clone git repository
+    git clone --depth 1 "$SRC_URL"
+}
+
+setup()
+{
+    : "
+    Setup all dependencies required to build
+    "
+    source_files
+    install_dependencies
+    obtain_repository
+
+    # Change directory into source code
+    cd $PKG_NAME
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    setup
+fi

--- a/packages/github/billw2/rpi-clone/start.sh
+++ b/packages/github/billw2/rpi-clone/start.sh
@@ -1,0 +1,80 @@
+#!/bin/env bash
+: "
+Begin building and installation of package
+"
+
+# Current script variable
+SCRIPTS=(setup.sh installer.sh)
+
+main()
+{
+    echo -e "Starting..."
+
+    # Source scripts
+    for script_pos in "${!SCRIPTS[@]}"; do
+        # Check if script exists
+        script="${SCRIPTS[$script_pos]}" # Get current script
+        echo -e "Script Number: $script_pos"
+        echo -e "Script Name: $script"
+        if [[ -f "$script" ]]; then
+            # If script exists, source
+            case "$script" in
+                "cleanup.sh")
+                    echo -e "[+] Starting cleanup process"
+                    ./$script
+                    res="$?"
+                    if [[ "$res" == "1" ]]; then
+                        # Error
+                        echo -e "Error with cleanup"
+                        exit
+                    fi
+                    ;;
+                "compile.sh")
+                    echo -e "[+] Starting Compilation"
+                    ./$script
+                    res="$?"
+                    if [[ "$res" == "1" ]]; then
+                        # Error
+                        echo -e "Error with compilation"
+                        exit
+                    fi
+                    read -p '[O] Compilation completed.' tmp
+                    ;;
+                "installer.sh")
+                    echo -e "[+] Starting installation"
+                    ./$script
+                    res="$?"
+                    if [[ "$res" == "1" ]]; then
+                        # Error
+                        echo -e "Error with installing"
+                        exit
+                    fi
+                    ;;
+                "setup.sh")
+                    echo -e "[+] Starting setup"
+                    ./$script
+                    res="$?"
+                    if [[ "$res" == "1" ]]; then
+                        # Error
+                        echo -e "Error with setup"
+                        exit
+                    fi
+                    ;;
+                *)
+                    # Invalid script
+                    echo -e "[+] Invalid script [$script], skipping..."
+                    ;;
+            esac
+
+            # new line
+            echo -e ""
+        fi
+    done
+
+    # Completed
+    echo -e "[O] Completed."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/packages/github/billw2/rpi-clone/uninstaller.sh
+++ b/packages/github/billw2/rpi-clone/uninstaller.sh
@@ -1,0 +1,52 @@
+#!/bin/env bash
+: "
+Manual Built from Source Package Uninstaller
+Uninstall manually compiled from source packages installed to host system
+Target Base System: Debian 
+Target Package Manager: apt
+"
+
+# Functions
+setup()
+{
+    : "
+    Setup all dependencies required to build
+    "
+    # Source settings file
+    source $PWD/settings.sh
+
+    # Check if package is installed
+    for binary in "${BIN_NAMES[@]}"; do
+        pkg_locations="$(which $binary)"
+        if [[ "$?" -gt 0 ]]; then
+            # = 0 = OK
+            # > 0 = Error
+            echo -e "Package $binary is not installed."
+            exit 1
+        fi
+    done
+}
+
+uninstall_pkg()
+{
+    : "
+    Uninstall the manually built from source package from host system
+    "
+    # Check if package is installed
+    for binary in "${BIN_NAMES[@]}"; do
+        rm -f $(which $binary) && \
+            echo -e "[+] Uninstallation of $binary Successful." || \
+            echo -e "[-] Uninstallation of $binary Error."
+    done
+}
+
+main()
+{
+    uninstall_pkg
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    setup
+    main "$@"
+fi
+


### PR DESCRIPTION
[New]
- Added new build repository for Disk Cloning utility 'rpi-clone' by billw2 that is mainly used for Raspberry Pi image cloning from microSD cards => SSD, but is actually distribution/platform-agnostic. - This is because it uses dd at its core, and is a wrapper for user-friendly UI